### PR TITLE
Add ldap version to ldap options

### DIFF
--- a/classes/ldapchecker.php
+++ b/classes/ldapchecker.php
@@ -58,6 +58,7 @@ class ldapchecker implements userstatusinterface {
             if (!$ldap) {
                 die("Could not connect to $config->host_url");
             }
+            ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, $config->ldap_version);
             $bind = ldap_bind($ldap, $config->bind_dn, $config->bind_pw); // Returns 1 if correct.
 
             if ($bind) {


### PR DESCRIPTION
Specify the LDAP version so that the correct protocol is used for binding.