### PR TITLE
Abort execution if ldab_bind fails

### DIFF
--- a/classes/ldapchecker.php
+++ b/classes/ldapchecker.php
@@ -83,7 +83,8 @@ class ldapchecker implements userstatusinterface {
 
                 $this->log("ldap server sent " . count($this->lookup) . " users");
             } else {
-                $this->log("ldap_bind failed");
+                // Abort on failure of ldap binding
+                die("ldap_bind failed");
             }
         }
     }


### PR DESCRIPTION
Currently the task is also executed if the ldap_bind fails. No users are retrieved from the LDAP, so all Moodle users with the  matching auth type are treated as if they did not exist in the ldap directory.   
This change cancels the task if ldap_bind has failed.